### PR TITLE
Support JDK and recent Android NDK

### DIFF
--- a/include/jnimock/jnimock.h
+++ b/include/jnimock/jnimock.h
@@ -44,53 +44,53 @@ struct JNIEnvMock : public JNIEnv {
 
     MOCK_METHOD1(AllocObject, jobject(jclass));
     MOCK_METHOD3(NewObjectV, jobject(jclass, jmethodID, va_list));
-    MOCK_METHOD3(NewObjectA,jobject(jclass, jmethodID, jvalue*));
+    MOCK_METHOD3(NewObjectA,jobject(jclass, jmethodID, const jvalue*));
 
 	MOCK_METHOD1(GetObjectClass, jclass(jobject));
 	MOCK_METHOD2(IsInstanceOf, jboolean(jobject, jclass));
 	MOCK_METHOD3(GetMethodID, jmethodID(jclass, const char*, const char*));
 
     MOCK_METHOD3(CallObjectMethodV, jobject(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallObjectMethodA, jobject(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallObjectMethodA, jobject(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallBooleanMethodV, jboolean(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallBooleanMethodA, jboolean(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallBooleanMethodA, jboolean(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallByteMethodV, jbyte(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallByteMethodA, jbyte(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallByteMethodA, jbyte(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallCharMethodV, jchar(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallCharMethodA, jchar(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallCharMethodA, jchar(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallShortMethodV, jshort(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallShortMethodA, jshort(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallShortMethodA, jshort(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallIntMethodV, jint(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallIntMethodA, jint(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallIntMethodA, jint(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallLongMethodV, jlong(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallLongMethodA, jlong(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallLongMethodA, jlong(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallFloatMethodV, jfloat(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallFloatMethodA, jfloat(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallFloatMethodA, jfloat(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallDoubleMethodV, jdouble(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallDoubleMethodA, jdouble(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallDoubleMethodA, jdouble(jobject, jmethodID, const jvalue*));
     MOCK_METHOD3(CallVoidMethodV, void(jobject, jmethodID, va_list));
-    MOCK_METHOD3(CallVoidMethodA, void(jobject, jmethodID, jvalue*));
+    MOCK_METHOD3(CallVoidMethodA, void(jobject, jmethodID, const jvalue*));
 
     MOCK_METHOD4(CallNonvirtualObjectMethodV, jobject(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualObjectMethodA, jobject(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualObjectMethodA, jobject(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualBooleanMethodV, jboolean(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualBooleanMethodA, jboolean(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualBooleanMethodA, jboolean(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualByteMethodV, jbyte(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualByteMethodA, jbyte(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualByteMethodA, jbyte(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualCharMethodV, jchar(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualCharMethodA, jchar(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualCharMethodA, jchar(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualShortMethodV, jshort(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualShortMethodA, jshort(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualShortMethodA, jshort(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualIntMethodV, jint(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualIntMethodA, jint(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualIntMethodA, jint(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualLongMethodV, jlong(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualLongMethodA, jlong(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualLongMethodA, jlong(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualFloatMethodV, jfloat(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualFloatMethodA, jfloat(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualFloatMethodA, jfloat(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualDoubleMethodV, jdouble(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualDoubleMethodA, jdouble(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualDoubleMethodA, jdouble(jobject, jclass, jmethodID, const jvalue*));
     MOCK_METHOD4(CallNonvirtualVoidMethodV, void(jobject, jclass,  jmethodID, va_list));
-    MOCK_METHOD4(CallNonvirtualVoidMethodA, void(jobject, jclass, jmethodID, jvalue*));
+    MOCK_METHOD4(CallNonvirtualVoidMethodA, void(jobject, jclass, jmethodID, const jvalue*));
 
 	MOCK_METHOD3(GetFieldID, jfieldID(jclass, const char*, const char*));
 
@@ -117,25 +117,25 @@ struct JNIEnvMock : public JNIEnv {
 	MOCK_METHOD3(GetStaticMethodID, jmethodID(jclass, const char*, const char*));
 
 	MOCK_METHOD3(CallStaticObjectMethodV, jobject(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticObjectMethodA, jobject(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticObjectMethodA, jobject(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticBooleanMethodV, jboolean(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticBooleanMethodA, jboolean(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticBooleanMethodA, jboolean(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticByteMethodV, jbyte(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticByteMethodA, jbyte(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticByteMethodA, jbyte(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticCharMethodV, jchar(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticCharMethodA, jchar(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticCharMethodA, jchar(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticShortMethodV, jshort(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticShortMethodA, jshort(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticShortMethodA, jshort(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticIntMethodV, jint(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticIntMethodA, jint(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticIntMethodA, jint(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticLongMethodV, jlong(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticLongMethodA, jlong(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticLongMethodA, jlong(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticFloatMethodV, jfloat(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticFloatMethodA, jfloat(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticFloatMethodA, jfloat(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticDoubleMethodV, jdouble(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticDoubleMethodA, jdouble(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticDoubleMethodA, jdouble(jclass, jmethodID, const jvalue*));
 	MOCK_METHOD3(CallStaticVoidMethodV, void(jclass, jmethodID, va_list));
-	MOCK_METHOD3(CallStaticVoidMethodA, void(jclass, jmethodID, jvalue*));
+	MOCK_METHOD3(CallStaticVoidMethodA, void(jclass, jmethodID, const jvalue*));
 
 	MOCK_METHOD3(GetStaticFieldID, jfieldID(jclass, const char*, const char*));
 

--- a/src/jnimock.cpp
+++ b/src/jnimock.cpp
@@ -116,7 +116,7 @@ static jobject NewObjectV(JNIEnv* env, jclass clazz,
 }
 
 static jobject NewObjectA(JNIEnv* env, jclass clazz,
-		jmethodID methodID, jvalue* args) {
+		jmethodID methodID, const jvalue* args) {
 	return ((JNIEnvMock*)env)->NewObjectA(clazz, methodID, args);
 }
 
@@ -154,7 +154,7 @@ static _jtype Call##_jname##MethodV(JNIEnv* env, jobject obj, jmethodID methodID
 #define JNI_CALL_TYPE_METHODA(_jtype, _jname)                                   		\
                                                            								\
 static _jtype Call##_jname##MethodA(JNIEnv* env, jobject obj, jmethodID methodID, 		\
-		jvalue* args) {                                                     			\
+		const jvalue* args) {                                                     			\
 	return ((JNIEnvMock*)env)->Call##_jname##MethodA(obj, methodID, args);				\
 }
 
@@ -186,7 +186,7 @@ static void CallVoidMethodV(JNIEnv* env, jobject obj,
 }
 
 static void CallVoidMethodA(JNIEnv* env, jobject obj,
-		jmethodID methodID, jvalue* args) {
+		jmethodID methodID, const jvalue* args) {
 	((JNIEnvMock*)env)->CallVoidMethodA(obj, methodID, args);
 }
 
@@ -212,7 +212,7 @@ static _jtype CallNonvirtual##_jname##MethodV(JNIEnv* env, jobject obj, jclass c
 #define JNI_CALL_NONVIRT_TYPE_METHODA(_jtype, _jname)                           		\
                                                            	   	   	   	   	   	   	   	\
 static _jtype CallNonvirtual##_jname##MethodA(JNIEnv* env, jobject obj, jclass clazz,	\
-		jmethodID methodID, jvalue* args) {                                 			\
+		jmethodID methodID, const jvalue* args) {                                 			\
 	return ((JNIEnvMock*)env)->CallNonvirtual##_jname##MethodA(obj, clazz,   			\
 				methodID, args);														\
 }
@@ -244,7 +244,7 @@ static void CallNonvirtualVoidMethodV(JNIEnv* env, jobject obj, jclass clazz,
 	((JNIEnvMock*)env)->CallNonvirtualVoidMethodV(obj, clazz, methodID, args);
 }
 static void CallNonvirtualVoidMethodA(JNIEnv* env, jobject obj, jclass clazz,
-    jmethodID methodID, jvalue* args) {
+    jmethodID methodID, const jvalue* args) {
 	((JNIEnvMock*)env)->CallNonvirtualVoidMethodA(obj, clazz, methodID, args);
 }
 
@@ -346,7 +346,7 @@ static _jtype CallStatic##_jname##MethodV(JNIEnv* env, jclass clazz,					\
 #define JNI_CALL_STATIC_TYPE_METHODA(_jtype, _jname)                            		\
                                                            								\
 static _jtype CallStatic##_jname##MethodA(JNIEnv* env, jclass clazz,  					\
-		jmethodID methodID, jvalue* args) {        										\
+		jmethodID methodID, const jvalue* args) {        										\
 	return ((JNIEnvMock*)env)->CallStatic##_jname##MethodA(clazz, methodID, args);		\
 }
 
@@ -377,7 +377,7 @@ static void CallStaticVoidMethodV(JNIEnv* env, jclass clazz,
 	((JNIEnvMock*)env)->CallStaticVoidMethodV(clazz, methodID, args);
 }
 static void CallStaticVoidMethodA(JNIEnv* env, jclass clazz,
-		jmethodID methodID, jvalue* args){
+		jmethodID methodID, const jvalue* args){
 	((JNIEnvMock*)env)->CallStaticVoidMethodA(clazz, methodID, args);
 }
 
@@ -697,7 +697,7 @@ static void GetStringRegion(JNIEnv* env, jstring str,
 
 static void GetStringUTFRegion(JNIEnv* env, jstring str,
 		jsize start, jsize len, char* buf) {
-	return ((JNIEnvMock*)env)->GetStringUTFRegion(str, start, len, buf);
+	((JNIEnvMock*)env)->GetStringUTFRegion(str, start, len, buf);
 }
 
 static void* GetPrimitiveArrayCritical(JNIEnv* env,
@@ -750,7 +750,7 @@ static jobjectRefType GetObjectRefType(JNIEnv* env, jobject obj) {
 }
 
 
-static const JNINativeInterface nativeInterface = {
+static const JNINativeInterface_ nativeInterface = {
 	NULL,
 	NULL,
 	NULL,
@@ -1047,8 +1047,8 @@ static jint DestroyJavaVM(JavaVM* vm) {
 	return ((JavaVMMock*)vm)->DestroyJavaVM();
 }
 
-static jint AttachCurrentThread(JavaVM* vm, JNIEnv** p_env, void* thr_args) {
-	return ((JavaVMMock*)vm)->AttachCurrentThread(p_env, thr_args);
+static jint AttachCurrentThread(JavaVM* vm, void** p_env, void* thr_args) {
+	return ((JavaVMMock*)vm)->AttachCurrentThread((JNIEnv**)p_env, thr_args);
 }
 
 static jint DetachCurrentThread(JavaVM* vm) {
@@ -1059,11 +1059,11 @@ static jint GetEnv(JavaVM* vm, void** env, jint version) {
 	return ((JavaVMMock*)vm)->GetEnv(env, version);
 }
 
-static jint AttachCurrentThreadAsDaemon(JavaVM* vm, JNIEnv** p_env, void* thr_args) {
-	return ((JavaVMMock*)vm)->AttachCurrentThreadAsDaemon(p_env, thr_args);
+static jint AttachCurrentThreadAsDaemon(JavaVM* vm, void** p_env, void* thr_args) {
+	return ((JavaVMMock*)vm)->AttachCurrentThreadAsDaemon((JNIEnv**)p_env, thr_args);
 }
 
-static const JNIInvokeInterface invokeInterface = {
+static const JNIInvokeInterface_ invokeInterface = {
 	NULL,
 	NULL,
 	NULL,

--- a/src/jnimock.cpp
+++ b/src/jnimock.cpp
@@ -749,6 +749,9 @@ static jobjectRefType GetObjectRefType(JNIEnv* env, jobject obj) {
 	return ((JNIEnvMock*)env)->GetObjectRefType(obj);
 }
 
+#ifdef __ANDROID__
+typedef JNINativeInterface JNINativeInterface_;
+#endif
 
 static const JNINativeInterface_ nativeInterface = {
 	NULL,
@@ -1043,11 +1046,18 @@ int destroyJNIEnvMock(JNIEnvMock* envMock) {
 // The JavaVMMock implementation for android
 //-----------------------------------------------------------------------------
 
+#ifdef __ANDROID__
+typedef JNIEnv** JVM_EnvPtr;
+typedef JNIInvokeInterface JNIInvokeInterface_;
+#else
+typdeef void** JVM_EnvPtr;
+#endif
+
 static jint DestroyJavaVM(JavaVM* vm) {
 	return ((JavaVMMock*)vm)->DestroyJavaVM();
 }
 
-static jint AttachCurrentThread(JavaVM* vm, void** p_env, void* thr_args) {
+static jint AttachCurrentThread(JavaVM* vm, JVM_EnvPtr p_env, void* thr_args) {
 	return ((JavaVMMock*)vm)->AttachCurrentThread((JNIEnv**)p_env, thr_args);
 }
 
@@ -1059,7 +1069,7 @@ static jint GetEnv(JavaVM* vm, void** env, jint version) {
 	return ((JavaVMMock*)vm)->GetEnv(env, version);
 }
 
-static jint AttachCurrentThreadAsDaemon(JavaVM* vm, void** p_env, void* thr_args) {
+static jint AttachCurrentThreadAsDaemon(JavaVM* vm, JVM_EnvPtr p_env, void* thr_args) {
 	return ((JavaVMMock*)vm)->AttachCurrentThreadAsDaemon((JNIEnv**)p_env, thr_args);
 }
 
@@ -1092,4 +1102,3 @@ int destroyJavaVMMock(JavaVMMock* vmMock) {
 }
 
 } // namespace jnimock
-


### PR DESCRIPTION
This PR pulls in support for the normal JDK, and should increase Android NDK support to at least 22.1